### PR TITLE
Add simple backoffice UI

### DIFF
--- a/src/main/kotlin/com/example/demo/adapter/inmemory/InMemoryPostRepository.kt
+++ b/src/main/kotlin/com/example/demo/adapter/inmemory/InMemoryPostRepository.kt
@@ -67,6 +67,9 @@ class InMemoryPostRepository : PostRepository {
 
     override fun findReported(): Flow<Post> = posts.filter { it.reportCount > 0 && !it.deleted }.asFlow()
 
+    override fun findByAuthorId(authorId: String): Flow<Post> =
+        posts.filter { it.authorId == authorId }.asFlow()
+
     override suspend fun reportPost(id: String): Post? {
         val post = findById(id) ?: return null
         post.reportCount++

--- a/src/main/kotlin/com/example/demo/adapter/postgres/PostgresPostRepository.kt
+++ b/src/main/kotlin/com/example/demo/adapter/postgres/PostgresPostRepository.kt
@@ -84,6 +84,12 @@ class PostgresPostRepository(
         }
     }
 
+    override fun findByAuthorId(authorId: String): Flow<Post> = flow {
+        postRepo.findByAuthorId(authorId).asFlow().collect { entity ->
+            emit(toDomain(entity))
+        }
+    }
+
     override suspend fun reportPost(id: String): Post? {
         val post = postRepo.findById(id).awaitSingleOrNull() ?: return null
         post.reportCount++

--- a/src/main/kotlin/com/example/demo/adapter/postgres/PostgresRepositories.kt
+++ b/src/main/kotlin/com/example/demo/adapter/postgres/PostgresRepositories.kt
@@ -3,7 +3,9 @@ package com.example.demo.adapter.postgres
 import org.springframework.data.r2dbc.repository.R2dbcRepository
 import reactor.core.publisher.Flux
 
-interface PostCrudRepository : R2dbcRepository<PostEntity, String>
+interface PostCrudRepository : R2dbcRepository<PostEntity, String> {
+    fun findByAuthorId(authorId: String): Flux<PostEntity>
+}
 interface CommentCrudRepository : R2dbcRepository<CommentEntity, String> {
     fun findByPostId(postId: String): Flux<CommentEntity>
 }

--- a/src/main/kotlin/com/example/demo/adapter/web/PostController.kt
+++ b/src/main/kotlin/com/example/demo/adapter/web/PostController.kt
@@ -38,6 +38,9 @@ class PostController(private val service: PostService) {
     @GetMapping
     suspend fun list(): Flow<Post> = service.getPosts()
 
+    @GetMapping("/user/{userId}")
+    suspend fun byUser(@PathVariable userId: String): Flow<Post> = service.getPostsByUser(userId)
+
     @GetMapping("/reported")
     suspend fun reported(@AuthenticationPrincipal auth: JwtAuthenticationToken): Flow<Post> =
         if (auth.authorities.any { it.authority == "ADMIN" || it.authority == "MODERATOR" })

--- a/src/main/kotlin/com/example/demo/application/PostService.kt
+++ b/src/main/kotlin/com/example/demo/application/PostService.kt
@@ -27,6 +27,8 @@ class PostService(
 
     fun getPosts(): Flow<Post> = repository.findAll()
 
+    fun getPostsByUser(userId: String): Flow<Post> = repository.findByAuthorId(userId)
+
     fun getReportedPosts(): Flow<Post> = repository.findReported()
 
     suspend fun getPost(id: String): Post? = repository.incrementViewCount(id)

--- a/src/main/kotlin/com/example/demo/domain/port/PostRepository.kt
+++ b/src/main/kotlin/com/example/demo/domain/port/PostRepository.kt
@@ -13,6 +13,7 @@ interface PostRepository {
     suspend fun deletePost(id: String): Boolean
     suspend fun deleteComment(postId: String, commentId: String, parentCommentId: String? = null): Boolean
     fun findReported(): Flow<Post>
+    fun findByAuthorId(authorId: String): Flow<Post>
     suspend fun reportPost(id: String): Post?
     suspend fun moderatePost(id: String, delete: Boolean): Post?
 }

--- a/src/main/resources/static/backoffice.html
+++ b/src/main/resources/static/backoffice.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Back Office</title>
+<script>
+let token = '';
+function setToken(){ token = document.getElementById('token').value; }
+function fetchAuth(url, options={}){
+  options.headers = options.headers || {};
+  if(token) options.headers['Authorization'] = 'Bearer ' + token;
+  return fetch(url, options).then(r=> r.ok ? r.json().catch(()=>({})) : r.text().then(t=>{throw t;}));
+}
+function loadPosts(){ fetchAuth('/posts').then(data=>{ document.getElementById('posts').textContent = JSON.stringify(data, null, 2); }); }
+function deletePost(){ const id=prompt('Post id to delete'); if(!id) return; fetchAuth('/posts/'+id,{method:'DELETE'}).then(()=>loadPosts()); }
+function deleteComment(){ const pid=prompt('Post id'); if(!pid) return; const cid=prompt('Comment id'); if(!cid) return; const parent=prompt('Parent comment id (optional)'); let url='/posts/'+pid+'/comments/'+cid; if(parent) url+='?parentCommentId='+parent; fetchAuth(url,{method:'DELETE'}).then(()=>alert('deleted')); }
+function loadUsers(){ fetchAuth('/users').then(data=>{ document.getElementById('users').textContent = JSON.stringify(data, null, 2); }); }
+function userPosts(){ const id=prompt('User id'); if(!id) return; fetchAuth('/posts/user/'+id).then(data=>{ document.getElementById('userPosts').textContent = JSON.stringify(data, null, 2); }); }
+function suspendUser(){ const id=prompt('User id'); if(!id) return; const mins=prompt('Minutes'); if(!mins) return; fetchAuth('/users/'+id+'/suspend',{method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({minutes: parseInt(mins)})}).then(()=>alert('suspended')); }
+</script>
+</head>
+<body>
+<h1>Back Office</h1>
+<label>JWT Token: <input id="token" type="text" size="60"><button onclick="setToken()">Set</button></label>
+<h2>Posts</h2>
+<button onclick="loadPosts()">Load Posts</button>
+<button onclick="deletePost()">Delete Post</button>
+<button onclick="deleteComment()">Delete Comment</button>
+<pre id="posts"></pre>
+<h2>Users</h2>
+<button onclick="loadUsers()">Load Users</button>
+<button onclick="userPosts()">Show User Posts</button>
+<button onclick="suspendUser()">Suspend User</button>
+<pre id="users"></pre>
+<h3>User Posts</h3>
+<pre id="userPosts"></pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add backoffice static HTML page
- expose new endpoint to list posts per user
- support finding posts by author in repositories and service

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684af5236abc8320810449e853b9b858