### PR TITLE
Remove Apple OAuth2 login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # a-board
 
 A simple anonymous board built with Spring Boot WebFlux and Kotlin.
-It supports OAuth2 login (Google, Apple and Facebook), posting text with optional images and gender display,
+It supports OAuth2 login (Google and Facebook), posting text with optional images and gender display,
 comments with one level of replies, and user management.
 Authentication is handled via JWT tokens issued by `/auth/token`. Each token contains a random anonymous ID so the real user ID is hidden when posting.
 Data is persisted in PostgreSQL via Spring Data R2DBC.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,5 +8,3 @@ spring.security.oauth2.client.registration.google.client-id=your-client-id
 spring.security.oauth2.client.registration.google.client-secret=your-client-secret
 spring.security.oauth2.client.registration.facebook.client-id=your-client-id
 spring.security.oauth2.client.registration.facebook.client-secret=your-client-secret
-spring.security.oauth2.client.registration.apple.client-id=your-client-id
-spring.security.oauth2.client.registration.apple.client-secret=your-client-secret


### PR DESCRIPTION
## Summary
- remove Apple OAuth configuration properties
- update README to mention only Google and Facebook

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_684c109932188320ae355777acd1bc5c