### PR TITLE
Add pagination support and hide author ID

### DIFF
--- a/src/main/kotlin/com/example/demo/adapter/web/PostController.kt
+++ b/src/main/kotlin/com/example/demo/adapter/web/PostController.kt
@@ -36,7 +36,10 @@ class PostController(private val service: PostService) {
         service.createPost(req.text, req.imageUrl, req.gender, auth.userId, auth.anonId)
 
     @GetMapping
-    suspend fun list(): Flow<Post> = service.getPosts()
+    suspend fun list(
+        @RequestParam(required = false, defaultValue = "0") offset: Int,
+        @RequestParam(required = false) limit: Int?
+    ): Flow<Post> = service.getPosts(offset, limit)
 
     @GetMapping("/user/{userId}")
     suspend fun byUser(@PathVariable userId: String): Flow<Post> = service.getPostsByUser(userId)

--- a/src/main/kotlin/com/example/demo/application/PostService.kt
+++ b/src/main/kotlin/com/example/demo/application/PostService.kt
@@ -5,6 +5,8 @@ import com.example.demo.domain.model.Post
 import com.example.demo.domain.port.PostRepository
 import com.example.demo.domain.port.UserRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.take
 import org.springframework.stereotype.Service
 
 @Service
@@ -25,7 +27,12 @@ class PostService(
         return repository.save(post)
     }
 
-    fun getPosts(): Flow<Post> = repository.findAll()
+    fun getPosts(offset: Int = 0, limit: Int? = null): Flow<Post> {
+        var flow = repository.findAll()
+        if (offset > 0) flow = flow.drop(offset)
+        if (limit != null) flow = flow.take(limit)
+        return flow
+    }
 
     fun getPostsByUser(userId: String): Flow<Post> = repository.findByAuthorId(userId)
 

--- a/src/main/kotlin/com/example/demo/domain/model/Post.kt
+++ b/src/main/kotlin/com/example/demo/domain/model/Post.kt
@@ -1,11 +1,12 @@
 package com.example.demo.domain.model
 
 import java.util.UUID
+import com.fasterxml.jackson.annotation.JsonIgnore
 
 data class Comment(
     val id: String = UUID.randomUUID().toString(),
     val postId: String,
-    val authorId: String,
+    @field:JsonIgnore val authorId: String,
     val anonymousId: String,
     val text: String,
     val parentCommentId: String? = null,
@@ -19,7 +20,7 @@ data class Post(
     val text: String,
     val imageUrl: String? = null,
     val gender: String? = null,
-    val authorId: String,
+    @field:JsonIgnore val authorId: String,
     val anonymousId: String,
     val comments: MutableList<Comment> = mutableListOf(),
     var viewCount: Int = 0,

--- a/src/test/kotlin/com/example/demo/PostServiceTests.kt
+++ b/src/test/kotlin/com/example/demo/PostServiceTests.kt
@@ -5,6 +5,7 @@ import com.example.demo.application.PostService
 import com.example.demo.adapter.inmemory.InMemoryUserRepository
 import com.example.demo.domain.model.User
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.toList
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -71,5 +72,19 @@ class PostServiceTests {
         } catch (e: IllegalStateException) {
             assertTrue(true)
         }
+    }
+
+    @Test
+    fun `get posts with limit and offset`() = runBlocking {
+        service.createPost("p1", null, null, "u1", "a1")
+        service.createPost("p2", null, null, "u2", "a2")
+        service.createPost("p3", null, null, "u3", "a3")
+
+        val firstTwo = service.getPosts(limit = 2).toList()
+        assertEquals(2, firstTwo.size)
+
+        val lastOne = service.getPosts(offset = 2, limit = 1).toList()
+        assertEquals(1, lastOne.size)
+        assertEquals("p3", lastOne.first().text)
     }
 }


### PR DESCRIPTION
## Summary
- add offset & limit params for `getPosts`
- omit authorId from Post JSON output
- hide authorId from Comment JSON output
- expose pagination via REST controller
- cover pagination in unit tests

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_684e9fbd5c6c83209e8f731cc3a12913