### PR TITLE
Indicate deletable posts/comments

### DIFF
--- a/src/main/kotlin/com/example/demo/adapter/postgres/PostgresPostRepository.kt
+++ b/src/main/kotlin/com/example/demo/adapter/postgres/PostgresPostRepository.kt
@@ -122,7 +122,8 @@ class PostgresPostRepository(
             comments = domainComments,
             viewCount = entity.viewCount,
             deleted = entity.deleted,
-            reportCount = entity.reportCount
+            reportCount = entity.reportCount,
+            canDelete = false
         )
     }
 
@@ -137,7 +138,8 @@ class PostgresPostRepository(
             parentCommentId = entity.parentCommentId,
             replies = replies,
             byPostAuthor = entity.byPostAuthor,
-            deleted = entity.deleted
+            deleted = entity.deleted,
+            canDelete = false
         )
     }
 }

--- a/src/main/kotlin/com/example/demo/adapter/web/PostController.kt
+++ b/src/main/kotlin/com/example/demo/adapter/web/PostController.kt
@@ -38,21 +38,28 @@ class PostController(private val service: PostService) {
     @GetMapping
     suspend fun list(
         @RequestParam(required = false, defaultValue = "0") offset: Int,
-        @RequestParam(required = false) limit: Int?
-    ): Flow<Post> = service.getPosts(offset, limit)
+        @RequestParam(required = false) limit: Int?,
+        @AuthenticationPrincipal auth: JwtAuthenticationToken
+    ): Flow<Post> = service.getPosts(offset, limit, auth.userId)
 
     @GetMapping("/user/{userId}")
-    suspend fun byUser(@PathVariable userId: String): Flow<Post> = service.getPostsByUser(userId)
+    suspend fun byUser(
+        @PathVariable userId: String,
+        @AuthenticationPrincipal auth: JwtAuthenticationToken
+    ): Flow<Post> = service.getPostsByUser(userId, auth.userId)
 
     @GetMapping("/reported")
     suspend fun reported(@AuthenticationPrincipal auth: JwtAuthenticationToken): Flow<Post> =
         if (auth.authorities.any { it.authority == "ADMIN" || it.authority == "MODERATOR" })
-            service.getReportedPosts()
+            service.getReportedPosts(auth.userId)
         else
             kotlinx.coroutines.flow.emptyFlow()
 
     @GetMapping("/{id}")
-    suspend fun get(@PathVariable id: String): Post? = service.getPost(id)
+    suspend fun get(
+        @PathVariable id: String,
+        @AuthenticationPrincipal auth: JwtAuthenticationToken
+    ): Post? = service.getPost(id, auth.userId)
 
     @PutMapping("/{id}")
     suspend fun update(

--- a/src/main/kotlin/com/example/demo/domain/model/Post.kt
+++ b/src/main/kotlin/com/example/demo/domain/model/Post.kt
@@ -13,6 +13,7 @@ data class Comment(
     val replies: MutableList<Comment> = mutableListOf(),
     var byPostAuthor: Boolean = false,
     var deleted: Boolean = false,
+    var canDelete: Boolean = false,
 )
 
 data class Post(
@@ -25,5 +26,6 @@ data class Post(
     val comments: MutableList<Comment> = mutableListOf(),
     var viewCount: Int = 0,
     var deleted: Boolean = false,
-    var reportCount: Int = 0
+    var reportCount: Int = 0,
+    var canDelete: Boolean = false,
 )


### PR DESCRIPTION
## Summary
- show whether a post or comment can be deleted by the requester
- expose requester id in listing, fetching and moderation endpoints
- mark objects as deletable in `PostService`
- extend integration tests to cover deletion flags

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684ea40fb8a483209383ab81a1e946a4