### PR TITLE
Fix duplicate view count increments

### DIFF
--- a/src/main/kotlin/com/example/demo/adapter/postgres/PostgresPostRepository.kt
+++ b/src/main/kotlin/com/example/demo/adapter/postgres/PostgresPostRepository.kt
@@ -58,12 +58,9 @@ class PostgresPostRepository(
     }
 
     override suspend fun incrementViewCount(id: String): Post? {
-        val post = postRepo.findById(id).awaitSingleOrNull() ?: return null
-        if (!post.deleted) {
-            post.viewCount++
-            postRepo.save(post).awaitSingle()
-        }
-        return toDomain(post)
+        val updated = postRepo.incrementViewCount(id).awaitSingleOrNull()
+        val entity = updated ?: postRepo.findById(id).awaitSingleOrNull() ?: return null
+        return toDomain(entity)
     }
 
     override suspend fun deletePost(id: String): Boolean {

--- a/src/main/kotlin/com/example/demo/adapter/postgres/PostgresRepositories.kt
+++ b/src/main/kotlin/com/example/demo/adapter/postgres/PostgresRepositories.kt
@@ -1,10 +1,15 @@
 package com.example.demo.adapter.postgres
 
 import org.springframework.data.r2dbc.repository.R2dbcRepository
+import org.springframework.data.r2dbc.repository.Query
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 interface PostCrudRepository : R2dbcRepository<PostEntity, String> {
     fun findByAuthorId(authorId: String): Flux<PostEntity>
+
+    @Query("UPDATE posts SET view_count = view_count + 1 WHERE id = :id AND deleted = false RETURNING *")
+    fun incrementViewCount(id: String): Mono<PostEntity>
 }
 interface CommentCrudRepository : R2dbcRepository<CommentEntity, String> {
     fun findByPostId(postId: String): Flux<CommentEntity>


### PR DESCRIPTION
## Summary
- prevent double increments by adding an atomic query to `PostCrudRepository`
- reuse the query in `PostgresPostRepository.incrementViewCount`

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684fb4e5a71083208996e3c65ac8eacb