### PR TITLE
Add relative time display for comments

### DIFF
--- a/src/main/kotlin/com/example/demo/domain/model/Post.kt
+++ b/src/main/kotlin/com/example/demo/domain/model/Post.kt
@@ -3,6 +3,7 @@ package com.example.demo.domain.model
 import java.util.UUID
 import java.time.Instant
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
 
 /**
  * In-memory representation of a single comment on a post. `authorId` is
@@ -20,7 +21,11 @@ data class Comment(
     var byPostAuthor: Boolean = false,
     var deleted: Boolean = false,
     var canDelete: Boolean = false,
-)
+) {
+    @get:JsonProperty("createdAgo")
+    val createdAgo: String
+        get() = createdAt.toAgoString()
+}
 /**
  * Post created by a user. Comments and view counts are embedded for convenience.
  * The authorId is kept server-side only.

--- a/src/main/kotlin/com/example/demo/domain/model/TimeAgo.kt
+++ b/src/main/kotlin/com/example/demo/domain/model/TimeAgo.kt
@@ -1,0 +1,15 @@
+package com.example.demo.domain.model
+
+import java.time.Instant
+import java.time.Duration
+
+fun Instant.toAgoString(): String {
+    val duration = Duration.between(this, Instant.now())
+    val minutes = duration.toMinutes()
+    return when {
+        minutes < 1 -> "방금전"
+        minutes < 60 -> "${minutes}분 전"
+        minutes < 60 * 24 -> "${duration.toHours()}시간 전"
+        else -> "${duration.toDays()}일 전"
+    }
+}


### PR DESCRIPTION
## Summary
- add `TimeAgo` helper for relative time strings
- expose `createdAgo` on `Comment` for comment/reply timestamps

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684ff1cb316c832087b8eb23139bf341